### PR TITLE
removing emoji support from mkdocs.yml

### DIFF
--- a/project/mkdocs.yml
+++ b/project/mkdocs.yml
@@ -47,9 +47,6 @@ markdown_extensions:
     - def_list
     - pymdownx.details
     - pymdownx.superfences
-    - pymdownx.emoji:
-        emoji_index: !!python/name:materialx.emoji.twemoji
-        emoji_generator: !!python/name:materialx.emoji.to_svg
     - toc:
         permalink: ⚓︎
         toc_depth: 5


### PR DESCRIPTION
Removing emoji support due to this: https://github.com/openSUSE/openSUSE-docs-revamped/issues/48