### PR TITLE
content: pick_an_image.md -- type-o, grammar, consistency fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ This is the construction site for the upcoming Leap and Tumbleweed documentation
 - Generic documentation based on Leap: https://doc.opensuse.org/
 - Tumbleweed specific knowledge-base: https://en.opensuse.org/Portal:Tumbleweed
 
+## Goal
+Take a look at the "About" section (right panel). You can also check [this](https://news.opensuse.org/2020/10/12/join-our-team-and-help-us-imporove-the-openSUSE-learning-experience/) out for context.
+
 ## Get in touch
 We often hang out on [this Telegram chat](https://t.me/opensuse_docs), which by the way is bridged to the IRC `#docs:opensuse.org` and to `#docs` on [this Discord channel](https://discord.gg/opensuse).
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ When lodging a PR please make sure to give us permission to commit to the Pull R
 * Then 
     1. clone this repo where you want in your home folder
     2. `cd` to it and run `pipenv install` to install the dependencies, and then `pipenv shell` to run the environment. 
-    3. finally `cd` to `project` and run you `mkdocs` commands from there, i.e. `mkdocs build` to generate the web content and `mkdocs serve` to serve it (by default at http://127.0.0.1:8000/). The built-in dev-server allows you to preview your documentation as you're writing it. It will even auto-reload and refresh your browser whenever you save your changes.
+    3. finally `cd` to `project` and run you `mkdocs` and `mkdocs-versioning` commands from there, i.e. `mkdocs build` to generate the web content and `mkdocs serve` to serve it (by default at http://127.0.0.1:8000/) (replace `mkdocs` with `mkdocs-versioning` if you want to produce a multi-version build instead). The built-in dev-server allows you to preview your documentation as you're writing it. It will even auto-reload and refresh your browser whenever you save your changes.
 * Available commands & documentation on mkdocs: https://www.mkdocs.org/
 
 ## Repo structure

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Take a look at the "About" section (right panel). You can also check [this](http
 * wikis make it difficult to sort the outdated / unofficial stuff from the up-to-date / official stuff
 * the official docs is slightly outdated, provides too little recommendations or best-practice advices on top of technical facts, is tedious to navigate at times and does not cater for Tumbleweed users.
 
-We are working with people from the official docs to move to a maintainer-centric model, which we believe will best serve the openSUSE community.
+We are working with people from the official docs to move to a maintainer-centric model, which we believe will better serve the openSUSE community.
 
 ## Getting in touch
 We often hang out on [this Telegram chat](https://t.me/opensuse_docs), which by the way is bridged to the IRC `#docs:opensuse.org` and to `#docs` on [this Discord channel](https://discord.gg/opensuse).

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ We often hang out on [this Telegram chat](https://t.me/opensuse_docs), which by 
 * Please try to comply with the guidelines under 'Commits' and 'Pull Requests' below.
 ### Branches
 * The default branch -- the working branch -- is not `main` or `master` but `dev`. I will merge from one milestone to the other.
-* _28 December 2020_: added `design-test` for trying out all things about design. Just create a merge request when you feel the design is so good as to deserve to be applied to `dev`.
 ### Commits
 4 types of commits. PRs should whenever possible concern just one type of commit:
  * `structure` (how the textual and multimedia contents breaks down into different parts)
@@ -25,9 +24,6 @@ We often hang out on [this Telegram chat](https://t.me/opensuse_docs), which by 
 New features should be proposed or discussed using `dev` as baseline, unless they refer to a particular `structure`-, `design`- or `contents`- commit.
 ### Pull Requests (PRs)
 When lodging a PR please make sure to give us permission to commit to the Pull Request branch by checking the `Allow edits from maintainers` checkbox on the Pull Request. Otherwise we won't be able to work with you on your PR.
-## Reviewing code
-* Amusing and relevant: https://mtlynch.io/code-review-love/#4-answer-questions-with-the-code-itself
-
 ## Building and serving the docs
 * You can either install mkdocs from pip or from a virtual environment.
 * It's highly recommended to use a virtual environment and not pip, so that the dependencies of this project won't mess with your system-wide python packages / modules. You still need to use pip to install pipenv though ;).
@@ -53,6 +49,7 @@ project/    # where you run your mkdocs commands from (while the pipenv commands
     ...
 ...
 ```
+`.gitignore` should not let you commit any `build` directory. Please make sure that is the case.
 ## Table of contents
 ### Before installing
 1. Choosing a distribution

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is the construction site for the upcoming Leap and Tumbleweed documentation
 ## Goal
 Take a look at the "About" section (right panel). You can also check [this](https://news.opensuse.org/2020/10/12/join-our-team-and-help-us-imporove-the-openSUSE-learning-experience/) out for context.
 
-## Get in touch
+## Getting in touch
 We often hang out on [this Telegram chat](https://t.me/opensuse_docs), which by the way is bridged to the IRC `#docs:opensuse.org` and to `#docs` on [this Discord channel](https://discord.gg/opensuse).
 ## Contributing
 * If you are not familiar with the fork -> pull request workflow, please refer to [this](https://jarv.is/notes/how-to-pull-request-fork-github/).

--- a/README.md
+++ b/README.md
@@ -6,8 +6,12 @@ This is the construction site for the upcoming Leap and Tumbleweed documentation
 - Generic documentation based on Leap: https://doc.opensuse.org/
 - Tumbleweed specific knowledge-base: https://en.opensuse.org/Portal:Tumbleweed
 
-## Goal
-Take a look at the "About" section (right panel). You can also check [this](https://news.opensuse.org/2020/10/12/join-our-team-and-help-us-imporove-the-openSUSE-learning-experience/) out for context.
+## Goals
+Take a look at the "About" section (right panel). You can also check [this](https://news.opensuse.org/2020/10/12/join-our-team-and-help-us-imporove-the-openSUSE-learning-experience/) out for context. If you wonder why we are doing this when there is already an official documentation along with wikis, the answer is two-fold a nutshell:
+* wikis make it difficult to sort the outdated / unofficial stuff from the up-to-date / official stuff
+* the official docs is slightly outdated, provides too little recommendations or best-practice advices on top of technical facts, is tedious to navigate at times and does not cater for Tumbleweed users.
+
+We are working with people from the official docs to move to a maintainer-centric model, which we believe will best serve the openSUSE community.
 
 ## Getting in touch
 We often hang out on [this Telegram chat](https://t.me/opensuse_docs), which by the way is bridged to the IRC `#docs:opensuse.org` and to `#docs` on [this Discord channel](https://discord.gg/opensuse).

--- a/project/docs/media_choice.md
+++ b/project/docs/media_choice.md
@@ -44,17 +44,17 @@ In what follows we make the following assumptions:
     ```
     $  gpg --recv-keys 0x22C07BA534178CD02EFE22AAB88B2FD43DBDC284
     ```
-4. (_Tumbleweed only_) You have obtained an openSUSE gpg __Detached Signature__ file corresponding to the image you want to perform the check upon. The Tumbleweed detached signature files are held within a single directory [here](http://download.opensuse.org/tumbleweed/iso/). Regarding Leap however you need to start [there](http://download.opensuse.org/distribution/openSUSE-current/) and use the `/live` subdirectory for the live images and the rescue images, and the `/iso` subdirectory for net installers and DVD images. Once you have the signature file, the command looks like this (i.e. for KDE Live):
+4. You have obtained an openSUSE gpg __Detached Signature__ file corresponding to the image you want to perform the check upon. The Tumbleweed detached signature files are held within a single directory [here](http://download.opensuse.org/tumbleweed/iso/). Regarding Leap however you need to start [there](http://download.opensuse.org/distribution/openSUSE-current/) and use the `/live` subdirectory for the live images and the rescue images (the `/iso` subdirectory does not provide any detached signature for net installers and DVD images). Once you have the address of the signature file, the command looks like this (i.e. for KDE Live):
     ```
     $  wget http://download.opensuse.org/tumbleweed/iso/openSUSE-Tumbleweed-KDE-Live-x86_64-Current.iso.sha256.asc
     ```
 
 ### Authenticity check
-For Tumbleweed the authenticity check is an instance of the command:
+For Tumbleweed (all images) and Leap (only live images) the authenticity check is an instance of the command:
 ```
 $  gpg --verify <Detached Signature.asc> <Target Checksum.iso.sha256>
 ```
-For Leap the authenticity check uses no signature (clearsign check); it is an instance of the command:
+For Leap non-live images (typically DVD images) the authenticity check uses no signature (clearsign check); it is an instance of the command:
 ```
 $  gpg --verify <Target Checksum.iso.sha256>
 ```

--- a/project/docs/pick_an_image.md
+++ b/project/docs/pick_an_image.md
@@ -11,7 +11,7 @@ Tumbleweed is a _rolling-release_ distribution: instead of having fixed points w
 ??? info
     Those components are called _packages_, because they "pack" the programs and resources making up most of your system, along with tools to install them). "Upgrading" means "Upgrading packages" (i.e. those that constitute you Linux distribution).
 
-Even though Tumbleweed uses a rolling-release model, it is very stable: the packages are thoroughly tested and tried, and you can always retreat to the previous state of Tumbleweed (in jargon: "switching to the previous snapshot". Snapshots are explained [here]()).
+Even though Tumbleweed uses a rolling-release model, it is very stable: the packages are thoroughly tested and tried, and you can always revert back to the previous state of Tumbleweed (in jargon: "switching to the previous snapshot". Snapshots are explained [here]()).
 
 What you have to bear in mind, however, is that Tumbleweed requires a reliable internet connection and a healthy hard drive to work as designed. It also requires that you sometimes take interest in the updating process.
 
@@ -21,24 +21,24 @@ Leap is a more traditional distribution -- it uses a fixed-points release model,
 It is worth noting that Leap provides a Linux kernel that is several years behind the version offered by Tumbleweed. 
 
 ??? info
-    The kernel is the heart of any Linux operating system. It is key for a smooth user experience with recent machines, especially laptops and computers heavily relying on periphericals
+    The kernel is the heart of any Linux operating system. It is key for a smooth user experience with recent machines, especially laptops and computers heavily relying on peripherals.
     
 This means that you might be better served by Tumbleweed if you have a recent computer or rely extensively on "exotic" hardware.
 
 ### Our recommendation
 Pick Tumbleweed if you intend to use your machine as a desktop machine, unless you are concerned with any of these blockers:
 
-* you don't want or you cannot update frequently over the network, because you have a very limited bandwidth or unreliable internet access
-* you cannot afford to reboot your computer frequently to install updates
-* you don't want to use, or for some reason cannot afford to switch between, different snapshots
-* you have an old computer (more than 7-year old) which cannot take advantage of recent kernels
-* you have a fixed set of packages you know you are going to install once and forget about, and usually you never wants to have anything to do with command line utilities
+* You don't want or you cannot update frequently over the network, because you have a very limited bandwidth or unreliable internet access.
+* You cannot afford to reboot your computer frequently to install updates.
+* You don't want to use, or for some reason cannot afford to switch between, different snapshots.
+* You have an old computer (more than 7-year old) which cannot take advantage of recent kernels.
+* You have a fixed set of packages you know you are going to install once and forget about, and usually you never wants to have anything to do with command line utilities.
 
 ??? info
-    Even though we don't recommend that if you are new user, it is possible to use microOS as a desktop computer, taking advantage of transactional updates. This might be interested if you are an advanced user and want to provide friends or relatives with an operating system that will require no maintenance for them, a very little for you. You might be interested in [this page]() for more about this use case.
+    It is not recommended for new users, however, it is possible to use microOS on a desktop computer, taking advantage of transactional updates. This might be appealing to advanced users who want to provide friends or relatives with an operating system that will require no maintenance from them, and very little from you. You might be interested in [this page]() for more about this use case.
 
 ## Desktop Environments
-Leap offers the __GNOME__ and __KDE Plasma__ desktop environments by default. Tumbleweed offers __GNOME__, __KDE Plasma__, and __XFCE__. These options are chosen during the __System Role__ selection of the installation. Additional options are available in the __Software__ selection of the installer. These desktop environment patterns may also be viewed and modified with the [YaST](/yast/) __Software Management__ module.
+Leap offers the __GNOME__ and __KDE Plasma__ desktop environments by default. Tumbleweed offers __GNOME__, __KDE Plasma__, and __XFCE__. These options are chosen during the __System Role__ section of the installation. Additional options are available in the __Software__ selection of the installer. These desktop environment patterns may also be viewed and modified with the [YaST](/yast/) __Software Management__ module.
 
 Modern desktop environments have evolved into highly consistent and productive computing experiences. Choosing the right desktop environment for you can be a deeply personal experience; many people feel as passionately about their desktop environment as they do their distribution. 
 
@@ -75,7 +75,7 @@ The descriptions below are as provided by the respective projects.
 >
 > Xfce embodies the traditional UNIX philosophy of modularity and re-usability. It consists of a number of components that provide the full functionality one can expect of a modern desktop environment. They are packaged separately and you can pick among the available packages to create the optimal personal working environment.
 >
-> Another priority of Xfce is adherence to standards, specifically those defined at freedesktop.org.
+> Another priority of Xfce is adherence to standards, specifically those defined at [freedesktop.org](https://www.freedesktop.org).
 >
 > [XFCE.org](https://www.xfce.org)
 
@@ -111,7 +111,7 @@ Before confirming the installation, an overview is provided with the selected in
 
 If you prefer one of these desktop environments, de-select the __A very basic desktop__ pattern, then select one of the below patterns:
 #### Enlightenment
-> Enlightenment is classed as a "desktop shell" as it provides everything you need to operate your desktop or laptop, but it is not a full application suite. This covers functionality including launching applications, managing their windows and performing system tasks like suspending, rebooting, managing files and so on.
+> Enlightenment is classified as a "desktop shell" as it provides everything you need to operate your desktop or laptop, but it is not a full application suite. This covers functionality including launching applications, managing their windows and performing system tasks like suspending, rebooting, managing files and so on.
 >
 >[Enlightenment.org](https://www.enlightenment.org)
 
@@ -141,7 +141,7 @@ If you prefer one of these desktop environments, de-select the __A very basic de
     !!! note
         Clicking the __Details...__ button on __Installer__ &gt; __Software Selection and System Tasks__ displays packages associated with the respective patterns. 
 #### LXQt
->  LXQt is a lightweight Qt desktop environment. It will not get in your way. It will not hang or slow down your system. It is focused on being a classic desktop with a modern look and feel.
+>  LXQt is a Lightweight Qt Desktop Environment. It will not get in your way. It will not hang or slow down your system. It is focused on being a classic desktop with a modern look and feel.
 > Historically, LXQt is the product of the merge between LXDE-Qt, an initial Qt flavour of LXDE, and Razor-qt, a project aiming to develop a Qt based desktop environment with similar objectives as the current LXQt.
 >
 > [LXQt-Project.org](https://lxqt-project.org)

--- a/project/mkdocs.yml
+++ b/project/mkdocs.yml
@@ -54,7 +54,7 @@ nav:
     - Home: index.md
     - Version Selector: "../"
     - Before installing:
-        - Choosing the right image: pick_an_image.md
+        - Choosing a distribution: pick_an_image.md
         - Installation setups: ""
         - Preparing the installation media: media_choice.md
     - Installing:


### PR DESCRIPTION
Fixed spelling and grammar. Capitalized list items. Added link for freedesktop.org in the XFCE section. Capitalized "Light QT Desktop Environment" to match case of "Light X11 Desktop Environment" for consistency.